### PR TITLE
allinea in centro il menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@
   border: 1px solid green;
 }
 .menu {
-  margin-left: 15rem;
+  margin: 0 auto;
 }
 .menu a {
   color: #E009A4;


### PR DESCRIPTION
`margin: 0 auto;` è una scorciatoia per:
- `margin-top: 0;`
- `margin-right: auto;`
- `margin-bottom: 0;`
- `margin-left: auto;`

impostando i margini laterali ad `auto` si permette all'elemento di centrarsi.
